### PR TITLE
Make the handling of entities generic to simplify microservice setup

### DIFF
--- a/api/handlers.py
+++ b/api/handlers.py
@@ -54,3 +54,28 @@ def do_meterpoint_query(dbconnection, variables, logger, entity):
             else:
                 logger.warning(f'Entity with _id : {entity["_id"]} has reading 0 but is Missing mch code or tmp_finishdate.')
     return entity
+
+
+def generic_handler(dbconnection, variables, logger, entity, query_keys):
+    """For a given entity, I query the given database and return the entity appended with 'query_result'
+
+    :param OracleDB dbconnection: Connection to a given database.
+    :param VariablesConfig variables: Object with environment variables.
+    :param sesam_logger logger: Logger to log info/errors to.
+    :param dict entity: Entity with keys to be used for the query.
+    :param list query_keys: Keys which are enclosed by brackets in the query.
+
+    :returns: Entity appended with query result.
+    :rtype: dict
+    """
+    if entity:
+        if query_keys:  # Check in case you want to do a static query
+            for k in query_keys:
+                if k not in entity:
+                    logger.error(f'Could not find query key "{k}" in entity: "{entity}". Returning entity w/o query')
+                    return entity
+
+        entity['query_result'] = dbconnection.do_query(str(variables.query).format(**entity))
+        return entity
+    else:
+        logger.warning(f'Input entity is None! generic_handler Returning None...')

--- a/api/handlers.py
+++ b/api/handlers.py
@@ -1,80 +1,15 @@
-
-
-def do_meterpoint_query(dbconnection, variables, logger, entity, query_keys):
-    """I'm used at Hafslund to grab readings for meterpoints from Quant
-        Maintaned by Gabriell Constantin Vig
-    """
-
-    def map_quant_ifs_readings(inner_entity, inner_query_result):
-        changed = False
-        include_estimate = inner_entity['tmp_include_estimate']
-        for key in inner_entity:
-            if 'uninstalled' in key and inner_entity[key] == '0':
-                if key == 'ifs-quadrantsreading:cons_uninstalled_reading':
-                    result = map_query(inner_query_result, 1, include_estimate)
-                    if result:
-                        inner_entity['ifs-quadrantsreading:cons_uninstalled_reading'] = str(result)
-                        changed = True
-                elif key == 'ifs-quadrantsreading:prod_uninstalled_reading':
-                    result = map_query(inner_query_result, 2, include_estimate)
-                    if result:
-                        inner_entity['ifs-quadrantsreading:prod_uninstalled_reading'] = str(result)
-                        changed = True
-                elif key == 'ifs-quadrantsreading:react_uninstalled_reading':
-                    result = map_query(inner_query_result, 3, include_estimate)
-                    if result:
-                        inner_entity['ifs-quadrantsreading:react_uninstalled_reading'] = str(result)
-                        changed = True
-                elif key == 'ifs-quadrantsreading:prod_react_uninstalled_reading':
-                    result = map_query(inner_query_result, 4, include_estimate)
-                    if result:
-                        inner_entity['ifs-quadrantsreading:react_uninstalled_reading'] = str(result)
-                        changed = True
-        if changed:
-            inner_entity['tmp_readings_from'] = 'Quant'
-        return inner_entity
-
-    def map_query(inner_query_result, type_code, include_estimate=False):
-        for r in inner_query_result:
-            if r[1] and r[1] == type_code:
-                if include_estimate and r[2] is not None:  # If estimate exists and we want it included
-                    return r[0] + r[2]  # return summation of reading + estimate
-                else:
-                    return r[0]  # else return only reading
-        return None
-
-    if 'ifs-quadrantsreading:cons_uninstalled_reading' in entity:
-        if entity['ifs-quadrantsreading:cons_uninstalled_reading'] == '0':
-            if entity['tmp_finishdate'] is not None and entity['tmp_mch_code'] is not None:
-                logger.debug('Doing query {}'.format(str(variables.query).format(**entity)))
-                query_result = dbconnection.do_query(str(variables.query).format(**entity))
-                for row in query_result:
-                    logger.debug(f'Query returned: {row}')
-                entity = map_quant_ifs_readings(inner_entity=entity, inner_query_result=query_result)
-            else:
-                logger.warning(f'Entity with _id : {entity["_id"]} has reading 0 but is Missing mch code or tmp_finishdate.')
-    return entity
-
-
-def generic_handler(dbconnection, variables, logger, entity, query_keys):
+def generic_handler(dbconnection, variables, logger, entity):
     """For a given entity, I query the given database and return the entity appended with 'query_result'
 
     :param OracleDB dbconnection: Connection to a given database.
     :param VariablesConfig variables: Object with environment variables.
     :param sesam_logger logger: Logger to log info/errors to.
     :param dict entity: Entity with keys to be used for the query.
-    :param list query_keys: Keys which are enclosed by brackets in the query.
 
     :returns: Entity appended with query result.
     :rtype: dict
     """
     if entity:
-        if query_keys:  # Check in case you want to do a static query
-            for k in query_keys:
-                if k not in entity:
-                    logger.error(f'Could not find query key "{k}" in entity: "{entity}". Returning entity w/o query')
-                    return entity
-
         entity['query_result'] = dbconnection.do_query(str(variables.query).format(**entity))
         return entity
     else:

--- a/api/handlers.py
+++ b/api/handlers.py
@@ -1,6 +1,6 @@
 
 
-def do_meterpoint_query(dbconnection, variables, logger, entity):
+def do_meterpoint_query(dbconnection, variables, logger, entity, query_keys):
     """I'm used at Hafslund to grab readings for meterpoints from Quant
         Maintaned by Gabriell Constantin Vig
     """

--- a/api/oracle_connection.py
+++ b/api/oracle_connection.py
@@ -5,29 +5,16 @@ from sesamutils.sesamlogger import sesam_logger
 class OracleDB:
     def __init__(self, host, port, database, username, password):
         """
-        A class used to connect to oracle databases
-        It automatically initiates the connection during creation.
-        ...
+        A class used to connect to oracle databases. It automatically initiates the connection during creation.
 
-        Attributes
-        ----------
-        host : str
-            host url or IP
-        port : int
-            Standard 1521, but can variate.
-        database : str
-            The database name
-        username : str
-        password : str
+        :param str host: Host to connect to. Either url or IP
+        :param int port: Port to use for connection.
+        :param str database: Database name.
+        :param username: :P
+        :param password: yeah...
 
-        Methods
-        -------
-        do_query(query)
-            Excecutes the query against the database and returns all results.
-
-        create_connection()
-            Initiates a connection to the database.
-
+        do_query(query): Executes the query against the database and returns all results.
+        create_connection(): Initiates a connection to the database.
         """
         self.logger = sesam_logger(logger_name='Database Connection', timestamp=True)
         self.host = host
@@ -41,20 +28,13 @@ class OracleDB:
     def do_query(self, query):
         """Returns the result of the query it is passed.
 
-        Does not support None as query.
-        It will automatically try to re-initate the database connection if the first try fails.
-        If this fails it will break.
+        It will automatically try to re-initate the database connection if it has dropped.
+            ^If this fails it will break.
 
-        Parameters
-        ----------
-        query : str
-            the query to excecute
+        :param str query: The query to excecute.
 
-        Returns
-        -------
-        list(list())
-            Each element of the list returned is a row.
-            Each row is a list of the column values returned by the query.
+        :returns: List of dictionaries where key is column name and value is column value eg [{col_n: col_v}]
+        :rtype: list(dict())
         """
 
         try:
@@ -63,9 +43,19 @@ class OracleDB:
             self.logger.warning(f'Got error "{e}".\nTrying to reconnect to Database!\n')
             self.connection = self.create_connection()
             self.cursor = self.connection.cursor()
-            self.logger.warning(f'Trying to do query again: "{query}".')
+            self.logger.warning(f'Connection successful! Trying to do query again: "{query}".')
             self.cursor.execute(query)
-        return self.cursor.fetchall()
+
+        # Match column names with column values to build [{column_name: column_value}, {...}, ...]
+        columns = self.cursor.description
+        output = []
+        for row in self.cursor.fetchall():
+            row_dict = {}
+            for index, column_value in enumerate(row):
+                row_dict[columns[index][0]] = column_value
+            output.append(row_dict)
+
+        return output
 
     def create_connection(self):
         """Creates a connection to the database using object values."""

--- a/api/oracle_connection.py
+++ b/api/oracle_connection.py
@@ -33,7 +33,7 @@ class OracleDB:
 
         :param str query: The query to excecute.
 
-        :returns: List of dictionaries where key is column name and value is column value eg [{col_n: col_v}]
+        :returns: List of dicts where dict = row and key = column name and value = column value eg [{col_n: col_v}]
         :rtype: list(dict())
         """
 
@@ -52,7 +52,7 @@ class OracleDB:
         for row in self.cursor.fetchall():
             row_dict = {}
             for index, column_value in enumerate(row):
-                row_dict[columns[index][0]] = column_value
+                row_dict[str(columns[index][0])] = str(column_value)
             output.append(row_dict)
 
         return output

--- a/api/service.py
+++ b/api/service.py
@@ -1,7 +1,6 @@
 from flask import Flask, Response, request
 import json
 import sys
-from re import findall
 
 #local imports
 from oracle_connection import OracleDB
@@ -34,21 +33,21 @@ def receiver():
 
     Make sure to append entities on their way in here with 'do_query': true/false. Unless you want to overload me
     """
-    # get entities from request
     req_entities = request.get_json()
     output = []
-    query_keys = findall('\{(.*?)\}', variables.query)#Regex to find all keys inside curly brackets in the query
-    if len(query_keys) == 0:
-        logger.warning('Query does not have keys enclosed in curly braces eg "{"_id"}"')
     try:
         for entity in req_entities:
+            logger.debug(f'Input entity: {json.dumps(entity)}')
             do_query = True  # If do_query is missing from the entity we will do the query anyways.
             if 'do_query' in entity:  # Check if entity has do_query key
                 do_query = entity['do_query']
+            else:
+                logger.warning(f'Key "do_query" is missing from the input entity! Doing query for EVERY entity.')
+
             if do_query:
-                handler = getattr(handlers, variables.handler)
-                entity = handler(databaseConnection, variables, logger, entity, query_keys)
-            logger.debug(f'Appending entity: {json.dumps(entity)} to output!')
+                handler = getattr(handlers, variables.handler) # Get the handler from env vars.
+                entity = handler(databaseConnection, variables, logger, entity) # Append entity with handler.
+            logger.debug(f'Output entity: {json.dumps(entity)}')
             output.append(entity)
     except TypeError as e:
         logger.critical('Wrong type gave error: {}'.format(e))


### PR DESCRIPTION
This PR aims to handle all kinds of query with a simple return value appended to the entity.

This means that when you set it up to do a query, you can now use "do_query" parameter so the microservice knows if it should append query info to an entity or not.

The query result will be appended to the entity using a list of dictionaries where each row is a dictionary and column name : column value as key:value.

please read readme for further instructions, as this has been modified to reflect the overall changes.